### PR TITLE
change to sync script in this repo, specify in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To use this pipeline, edit parameters in the config_preprocessing.yaml, and spec
 1. directory path containing demultiplexed raw fastq files (DATA_DIR)
 2. root directory path for output files (PROJECT_DIR)
 3. directory path for the host reference genome (BWA index)
+4. Directory of the scripts folder from the github, contains sync.py and plot_readcounts.R
 
 *This program runs under the assumption samples are named <sample_id>\_[R]1.fastq[fq].gz and <sample_id>\_[R]2.fastq[fq].gz.* The R1/R2 and suffix must be specified in the config. 
 

--- a/preprocessing/config_preprocessing.yaml
+++ b/preprocessing/config_preprocessing.yaml
@@ -3,6 +3,8 @@ raw_reads_directory: raw_data
 output_directory: preprocessing
 read_specification: ['R1', 'R2'] #['1', '2'] # or ['R1', 'R2']
 extension: .fastq.gz # or .fastq.gz (should be gzipped regardless) - must include the period!
+# scripts direcrory in the github repo - has sync.py and plot_readcounts.R
+scripts_dir: scripts
 
 # specify parameters for TrimGalore -- automatically chcecks the adaptor type
 trim_galore:

--- a/preprocessing/preprocessing.snakefile
+++ b/preprocessing/preprocessing.snakefile
@@ -122,9 +122,11 @@ rule sync:
 		fwd = join(PROJECT_DIR, "01_processing/03_sync/{sample}_1.fq"),
 		rev = join(PROJECT_DIR, "01_processing/03_sync/{sample}_2.fq"),
 		orp = join(PROJECT_DIR, "01_processing/03_sync/{sample}_orphans.fq")
+	params: 
+		scripts_folder = config["scripts_dir"]
 	shell: """
 		mkdir -p {PROJECT_DIR}/01_processing/03_sync/
-		/labs/asbhatt/ribado/tools/bhattlab_workflows/preprocessing/scripts/sync.py {input.rep_fwd} {input.fwd} {input.rev} {output.fwd} {output.rev} {output.orp}
+		{params.scripts_folder}/sync.py {input.rep_fwd} {input.fwd} {input.rev} {output.fwd} {output.rev} {output.orp}
 	"""
 
 ################################################################################
@@ -163,9 +165,11 @@ rule rm_host_sync:
 		fwd = join(PROJECT_DIR, "01_processing/05_sync/{sample}_1.fq"),
 		rev = join(PROJECT_DIR, "01_processing/05_sync/{sample}_2.fq"),
 		orp = join(PROJECT_DIR, "01_processing/05_sync/{sample}_orphans.fq")
+	params: 
+		scripts_folder = config["scripts_dir"]
 	shell: """
 		mkdir -p {PROJECT_DIR}/01_processing/05_sync/
-		/labs/asbhatt/ribado/tools/bhattlab_workflows/preprocessing/scripts/sync.py {input.rep_fwd} {input.fwd} {input.rev} {output.fwd} {output.rev} {output.orp}
+		{params.scripts_folder}/sync.py {input.rep_fwd} {input.fwd} {input.rev} {output.fwd} {output.rev} {output.orp}
 		# concatinate the orphans reads after host removal with the orphan reads from syncing prior to host removal
 		cat {input.orp} >> {output.orp}
 
@@ -283,5 +287,7 @@ rule readcounts_graph:
 		rules.readcounts.output
 	output:
 		join(PROJECT_DIR, "01_processing/readcounts.pdf")
+	params: 
+		scripts_folder = config["scripts_dir"]
 	script:
-		"scripts/plot_readcounts.R"
+		join("{params.scripts_folder}", "plot_readcounts.R")


### PR DESCRIPTION
Fixes issue #7, uses python3 sync script in this repo. Must specify scripts dir in config file (symlink it to the current working dir, or provide the path of this repo locally)