### PR TITLE
Merge Sort reads branch with master

### DIFF
--- a/preprocessing/preprocessing.snakefile
+++ b/preprocessing/preprocessing.snakefile
@@ -25,10 +25,10 @@ localrules: assembly_meta_file, pre_multiqc, post_multiqc, cleanup
 rule all:
 	input:
 		expand(join(PROJECT_DIR, "01_processing/05_sync/{sample}_orphans.fq.gz"), sample=SAMPLE_PREFIX),
-		# expand(join(PROJECT_DIR, "01_processing/00_qc_reports/pre_fastqc/{sample}_{read}_fastqc.html"), sample=SAMPLE_PREFIX, read=READ_SUFFIX),
-		# expand(join(PROJECT_DIR, "01_processing/00_qc_reports/post_fastqc/{sample}_{read}_fastqc.html"), sample=SAMPLE_PREFIX, read=['1', '2', 'orphans']),
-		# join(PROJECT_DIR, "01_processing/00_qc_reports/pre_multiqc/multiqc_report.html"),
-		# join(PROJECT_DIR, "01_processing/00_qc_reports/post_multiqc/multiqc_report.html"),
+		expand(join(PROJECT_DIR, "01_processing/00_qc_reports/pre_fastqc/{sample}_{read}_fastqc.html"), sample=SAMPLE_PREFIX, read=READ_SUFFIX),
+		expand(join(PROJECT_DIR, "01_processing/00_qc_reports/post_fastqc/{sample}_{read}_fastqc.html"), sample=SAMPLE_PREFIX, read=['1', '2', 'orphans']),
+		join(PROJECT_DIR, "01_processing/00_qc_reports/pre_multiqc/multiqc_report.html"),
+		join(PROJECT_DIR, "01_processing/00_qc_reports/post_multiqc/multiqc_report.html"),
 		join(PROJECT_DIR, "01_processing/assembly_input.txt"),
 		join(PROJECT_DIR, "01_processing/classification_input.txt"),
 		join(PROJECT_DIR, "01_processing/readcounts.tsv"),

--- a/preprocessing/preprocessing.snakefile
+++ b/preprocessing/preprocessing.snakefile
@@ -114,10 +114,11 @@ rule sort_trimmed_fwd:
 		mem=64,
 		time=lambda wildcards, attempt: attempt * 6
 	shell: """
-		zcat -f {input.fwd} | paste - - - - | sort -k1,1 -t " " | tr "\t" "\n" | gzip > {output.fwd}
+		export LC_ALL=C 
+		zcat -f {input.fwd} | paste - - - - | sort -k1,1 | tr "\t" "\n" | gzip > {output.fwd} || test $? -eq 141	
 		
 		# remove old unsorted input
-		rm {input.fwd}
+		# rm {input.fwd}
 	"""
 
 rule sort_trimmed_rev:
@@ -129,10 +130,11 @@ rule sort_trimmed_rev:
 		mem=64,
 		time=lambda wildcards, attempt: attempt * 6
 	shell: """
-		zcat -f {input.rev} | paste - - - - | sort -k1,1 -t " " | tr "\t" "\n" | gzip > {output.rev}
+		export LC_ALL=C 
+		zcat -f {input.rev} | paste - - - - | sort -k1,1 | tr "\t" "\n" | gzip > {output.rev} || test $? -eq 141	
 		
 		# remove old unsorted input
-		rm {input.rev}
+		# rm {input.rev}
 	"""
 
 rule sort_trimmed_orp:
@@ -144,28 +146,23 @@ rule sort_trimmed_orp:
 		mem=64,
 		time=lambda wildcards, attempt: attempt * 6
 	shell: """
-		zcat -f {input.orp} | paste - - - - | sort -k1,1 -t " " | tr "\t" "\n" | gzip > {output.orp}
+		export LC_ALL=C 
+		zcat -f {input.orp} | paste - - - - | sort -k1,1 | tr "\t" "\n" | gzip > {output.orp} || test $? -eq 141	
 		
 		# remove old unsorted input
-		rm {input.rev}
+		# rm {input.orp}
 	"""
 
 
 ################################################################################
-rule dereplicate:
+rule dereplicate_fwd:
 	input:
 		fwd = rules.sort_trimmed_fwd.output,
-		rev = rules.sort_trimmed_rev.output,
-		orp = rules.sort_trimmed_orp.output
 	output:
 		fwd = join(PROJECT_DIR, "01_processing/02_dereplicate/{sample}_nodup_PE1.fastq"),
-		rev = join(PROJECT_DIR, "01_processing/02_dereplicate/{sample}_nodup_PE2.fastq"),
-		orp = join(PROJECT_DIR, "01_processing/02_dereplicate/{sample}_nodup_unpaired.fastq")
 	params:
 		outdir = join(PROJECT_DIR, "01_processing/02_dereplicate/"),
 		details_fwd = join(PROJECT_DIR, "01_processing/02_dereplicate/{sample}_1_details.txt"),
-		details_rev = join(PROJECT_DIR, "01_processing/02_dereplicate/{sample}_2_details.txt"),
-		details_orp = join(PROJECT_DIR, "01_processing/02_dereplicate/{sample}_unpaired_details.txt")
 	threads: 2
 	resources:
 		mem=32,
@@ -174,16 +171,51 @@ rule dereplicate:
 	shell: """
 		mkdir -p {params.outdir}
 		seqkit rmdup --by-seq {input.fwd} -D {params.details_fwd} > {output.fwd}
-		seqkit rmdup --by-seq {input.rev} -D {params.details_rev} > {output.rev}
-		seqkit rmdup --by-seq {input.orp} -D {params.details_orp} > {output.orp}
-
 	"""
+
+rule dereplicate_rev:
+	input:
+		rev = rules.sort_trimmed_rev.output,
+	output:
+		rev = join(PROJECT_DIR, "01_processing/02_dereplicate/{sample}_nodup_PE2.fastq"),
+	params:
+		outdir = join(PROJECT_DIR, "01_processing/02_dereplicate/"),
+		details_rev = join(PROJECT_DIR, "01_processing/02_dereplicate/{sample}_2_details.txt"),
+	threads: 2
+	resources:
+		mem=32,
+		time=24
+	singularity: "docker://quay.io/biocontainers/seqkit:0.10.1--1"
+	shell: """
+		mkdir -p {params.outdir}
+		seqkit rmdup --by-seq {input.rev} -D {params.details_rev} > {output.rev}
+	"""
+
+rule dereplicate_orp:
+	input:
+		orp = rules.sort_trimmed_orp.output
+	output:
+		orp = join(PROJECT_DIR, "01_processing/02_dereplicate/{sample}_nodup_unpaired.fastq")
+	params:
+		outdir = join(PROJECT_DIR, "01_processing/02_dereplicate/"),
+		details_orp = join(PROJECT_DIR, "01_processing/02_dereplicate/{sample}_unpaired_details.txt")
+	threads: 2
+	resources:
+		mem=32,
+		time=24
+	singularity: "docker://quay.io/biocontainers/seqkit:0.10.1--1"
+	shell: """
+		mkdir -p {params.outdir}
+		seqkit rmdup --by-seq {input.orp} -D {params.details_orp} > {output.orp}
+	"""
+
 ################################################################################
 rule sync:
 	input:
-		rep_fwd  = rules.sort_trimmed_fwd.output,
-		fwd = rules.dereplicate.output.fwd,
-		rev = rules.dereplicate.output.rev
+		rep_fwd  = rules.sort_trimmed_fwd.output.fwd,
+		fwd = rules.dereplicate_fwd.output.fwd,
+		rev = rules.dereplicate_rev.output.rev,
+		orp = rules.dereplicate_orp.output.orp
 	output:
 		fwd = join(PROJECT_DIR, "01_processing/03_sync/{sample}_1.fq"),
 		rev = join(PROJECT_DIR, "01_processing/03_sync/{sample}_2.fq"),
@@ -222,7 +254,7 @@ rule rm_host_reads:
 ################################################################################
 rule rm_host_sync:
 	input:
-		rep_fwd  = rules.sort_trimmed_fwd.output,
+		rep_fwd  = rules.sort_trimmed_fwd.output.fwd,
 		fwd = rules.rm_host_reads.output.unmapped_1,
 		rev = rules.rm_host_reads.output.unmapped_2,
 		orp = rules.rm_host_reads.output.unmapped_orp

--- a/preprocessing/scripts/sync.py
+++ b/preprocessing/scripts/sync.py
@@ -33,7 +33,9 @@ import gzip
 import re
 import sys
 import shutil
-
+import functools
+import locale
+locale.setlocale(locale.LC_ALL, "C")
 
 # natural sort function from Mark Byers on Stack Overflow
 def natural_sort(l): 
@@ -94,12 +96,38 @@ def sync_paired_end_reads(original, reads_a, reads_b, synced_a, synced_b, orphan
 
         # files need to be in read name sorted order for this to work. Check 
         # if thats not the case here
-        if (ha != '' and natural_sort([header,ha])[0] != header) or \
-                   (hb != '' and natural_sort([header,hb])[0] != header):
+        l1 = [header,ha]
+        l2 = [header,hb]
+        l1_sorted = l1.copy()
+        l2_sorted = l2.copy()
+        l1_sorted.sort(key=functools.cmp_to_key(locale.strcoll))
+        l2_sorted.sort(key=functools.cmp_to_key(locale.strcoll))
+        if (ha != '' and l1_sorted[0] != header) or \
+                   (hb != '' and l2_sorted[0] != header):
+        # if (ha != '' and l1_natural[0] != header) or \
+        #            (hb != '' and l2_natural[0] != header):
+            l1_sorted2 = l1.copy()
+            l2_sorted2 = l2.copy()
+            l1_sorted2.sort()
+            l2_sorted2.sort()
+            l1_natural = natural_sort(l1)
+            l2_natural = natural_sort(l2)
             print('Reads must be in read name sorted order. Please sort and re-run.')
             print("Original reads: " + header)
-            print("Sync 1 reads: " + ha)
-            print("Sync 2 reads: " + hb)
+            print("Sync 1 reads:   " + ha)
+            print("Sync 2 reads:   " + hb)
+            print('Original')
+            print(l1)
+            print(l2)
+            print('default sorted')
+            print(l1_sorted)
+            print(l2_sorted)
+            print('default sorted no localle')
+            print(l1_sorted2)
+            print(l2_sorted2)
+            print('natural sorted')
+            print(l1_natural)
+            print(l2_natural)
             raise ValueError
  
         if header == ha and header != hb:
@@ -130,6 +158,9 @@ def sync_paired_end_reads(original, reads_a, reads_b, synced_a, synced_b, orphan
 
 
 def _open(filename, mode='r'):
+    # print(filename)
+    # print(type(filename))
+    # print(type(filename[0]))
     if filename.endswith('.gz'):
         # if mode.startswith('w'):
             # return gzip.open(filename, 'wb')


### PR DESCRIPTION
Necessary changes to work with any read files that were unsorted. Previously these would fail without error. 
 - sort rule in snakemake to lexically sort reads
 - check for sorted reads in sync script (slightly longer runtime but necessary)
 - split dereplicate into separate rules (parallelization!)