### PR TITLE
use github (ghcr.io) as the docker container registry

### DIFF
--- a/metariboseq/docker/bhattlab-base/build.sh
+++ b/metariboseq/docker/bhattlab-base/build.sh
@@ -1,1 +1,1 @@
-docker build --squash -t cosmosnicolaou/bhattlab-ubuntu-focal-base .
+docker build --squash -t ghcr.io/bhattlab/bhattlab-ubuntu-focal-base .

--- a/metariboseq/docker/bhattlab-base/push.sh
+++ b/metariboseq/docker/bhattlab-base/push.sh
@@ -1,1 +1,1 @@
-docker push --disable-content-trust=false cosmosnicolaou/bhattlab-ubuntu-focal-base:latest
+docker push ghcr.io/bhattlab/bhattlab-ubuntu-focal-base:latest

--- a/metariboseq/docker/metariboseq/Dockerfile
+++ b/metariboseq/docker/metariboseq/Dockerfile
@@ -1,4 +1,4 @@
-FROM cosmosnicolaou/bhattlab-ubuntu-focal-base
+FROM ghcr.io/cosnicolaou/bhattlab-ubuntu-focal-base
 
 # install linux packages
 USER root

--- a/metariboseq/docker/metariboseq/build.sh
+++ b/metariboseq/docker/metariboseq/build.sh
@@ -1,2 +1,1 @@
-docker build -t cosmosnicolaou/bhattlab-metariboseq .
-#docker build --squash -t cosmosnicolaou/bhattlab-metariboseq .
+docker build -t ghcr.io/bhattlab/bhattlab-metariboseq .

--- a/metariboseq/docker/metariboseq/push.sh
+++ b/metariboseq/docker/metariboseq/push.sh
@@ -1,1 +1,1 @@
-docker push --disable-content-trust=false cosmosnicolaou/bhattlab-metariboseq:latest
+docker push ghcr.io/bhattlab/bhattlab-metariboseq:latest

--- a/metariboseq/singularity/metariboseq/metariboseq.def
+++ b/metariboseq/singularity/metariboseq/metariboseq.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: cosmosnicolaou/bhattlab-metariboseq:latest
+From: ghcr.io/bhattlab/bhattlab-metariboseq:latest
 
 %environment
     export LC_ALL=C


### PR DESCRIPTION
This PR switches to using ghcr.io as the registry for docker containers. The containers created are now associated with this repo and publicly available.