### PR TITLE
metariboseq updates

### DIFF
--- a/metariboseq/nextflow-configs/slurm.config
+++ b/metariboseq/nextflow-configs/slurm.config
@@ -1,7 +1,7 @@
 process {
     executor="slurm"
     queue="batch"
-    time="72h"
+    time="144h"
     clusterOptions="--account asbhatt"
 }
 
@@ -9,5 +9,5 @@ singularity {
     enabled = true
     autoMounts = true
     engineOptions = "-v"
-    runOptions = "-B /oak/stanford/scg/lab_asbhatt/cosn"
+    runOptions = "--bind /oak/stanford/scg/lab_asbhatt/cosn,/oak/stanford/scg/lab_asbhatt/mpgriesh:/oak/stanford/scg/lab_asbhatt/mpgriesh:ro"
 }

--- a/metariboseq/workflows/analysis/metariboseq-analysis.nf
+++ b/metariboseq/workflows/analysis/metariboseq-analysis.nf
@@ -11,7 +11,7 @@ workflow {
 
         prepare_riboDat = Channel.from(params.sampleSpecs)
             .map{ [ name: it.name,
-                    metariboseq: "${params.resultsPrefix}/" + it.name + ".bam",
+                    metariboseq: "${params.resultsPrefix}/" + it.metariboseq + ".bam",
                     script: "${params.analysisScriptDir}/prepare-ribodat.R"] }
 
         samples = Channel.from(params.sampleSpecs)

--- a/metariboseq/workflows/analysis/metariboseq-analysis.nf
+++ b/metariboseq/workflows/analysis/metariboseq-analysis.nf
@@ -1,23 +1,120 @@
 #!/usr/bin/env nextflow
 
-toAnalyze = Channel.from(params.sampleSpecs)
+workflow {
+    main:
+        prepare_fastaCDA = Channel.from(params.sampleSpecs)
+            .map{ [ name: it.metagenomic,
+                    metagenomic: "${params.resultsPrefix}/" + it.metagenomic + "-assembly/contigs.fasta",
+                    script: "${params.analysisScriptDir}/prepare-fastaCDS.R"] }
+            .unique()
+
+
+        prepare_riboDat = Channel.from(params.sampleSpecs)
+            .map{ [ name: it.name,
+                    metariboseq: "${params.resultsPrefix}/" + it.name + ".bam",
+                    script: "${params.analysisScriptDir}/prepare-ribodat.R"] }
+
+        samples = Channel.from(params.sampleSpecs)
+            .map { [it.name, it.metagenomic, it.metariboseq] }
+
+        fastaCDS = prepareFastaCDA(prepare_fastaCDA)
+        riboDat = prepareRiboDat(prepare_riboDat)
+
+        combined = samples.combine(riboDat, by: 0)
+            .map{ [it[1], it[0], it[2], it[3]]} // move the metagenome to the front
+            .combine(fastaCDS, by: 0)
+            .map{ [it[1], it[4], it[3]]} // keep the sample name, fastaCDS and ribodat
+
+        prepare_counts = combined
+            .map{ [it[0], it[1], it[2], "${params.analysisScriptDir}/prepare-counts.R"]}
+
+        with_counts = prepareCounts(prepare_counts)
+
+        plots = with_counts
+            .map{ [it[0], it[1], it[2], it[3], "${params.analysisScriptDir}/plotVisualsRibo.R"] }
+
+        generatePlots(plots)
+}
+
+process prepareFastaCDA {
+    memory "${params.assemblyMemory}"
+
+    input:
+        tuple val(name), path(metagenomic), path(script)
+
+    output:
+        tuple val(name), path("${name}-fastaCDS.RData")
+
+    shell:
+    """
+    Rscript !{script} !{metagenomic} !{name}-fastaCDS.RData
+    """
+
+    stub:
+    """
+    touch "${name}-fastaCDS.RData"
+    """
+}
+
+process prepareRiboDat {
+    memory "${params.assemblyMemory}"
+
+    input:
+        tuple val(name), path(metariboseq), path(script)
+
+    output:
+        tuple val(name), path("${name}-ribodata.RData")
+
+    shell:
+    """
+    Rscript !{script} !{metariboseq} !{name}-ribodata.RData
+    """
+
+    stub:
+    """
+    touch "${name}-ribodata.RData"
+    """
+}
+
+process prepareCounts {
+    memory "${params.assemblyMemory}"
+
+    input:
+        tuple val(name), path(fastaCDS), path(ribodat), path(script)
+
+    output:
+        tuple val(name), path(fastaCDS), path(ribodat), path("${name}-counts.RData")
+
+    shell:
+    """
+    Rscript !{script} !{fastaCDS} !{ribodat} !{name}-counts.RData
+    """
+
+    stub:
+    """
+    touch "${name}-counts.RData"
+    """
+}
 
 // Plots are generated using the metagenomic assembly and the metariboseq
 // alignments.
 process generatePlots {
     memory "${params.assemblyMemory}"
+    publishDir "${params.resultsPrefix}/${name}-plots/", mode: "copy"
 
     input:
-        val(sample) from toAnalyze
-        path script from "${params.analysisScript}"
-
-    publishDir "${params.resultsPrefix}/${sample.name}-plots/", mode: "copy"
+        tuple val(name), path(metagenomic),path(metariboseq), path(counts), path(script)
 
     output:
         path("*.pdf")
 
     shell:
     """
-    Rscript !{script} !{params.resultsPrefix}/!{sample.name}-assembly/contigs.fasta !{params.resultsPrefix}/!{sample.metariboseq}.bam
+    Rscript !{script} !{metagenomic} !{metariboseq} !{counts}
+    """
+
+    stub:
+    """
+    echo Rscript ${script} ${metagenomic} ${metariboseq} ${counts} > dummy-stub.pdf
     """
 }

--- a/metariboseq/workflows/analysis/prepare-assembly.R
+++ b/metariboseq/workflows/analysis/prepare-assembly.R
@@ -1,0 +1,9 @@
+# Takes arguments - 1: fasta file
+library(riboSeqR)
+
+chlamyFasta <- (args[1])
+chlamyFastaState <- paste(basename(chlamyFasta), ".RData", sep = '')
+fastaCDS <- findCDS(fastaFile = chlamyFasta,startCodon = c("ATG"),stopCodon = c("TAG", "TAA", "TGA"))
+
+# Load in asssembly and annotate ORFs
+save(fastaCDA, file=chlamyFastaState)

--- a/metariboseq/workflows/analysis/prepare-counts.R
+++ b/metariboseq/workflows/analysis/prepare-counts.R
@@ -1,0 +1,17 @@
+#Takes arguments - 1: fasta .RData file, 2: Ribo bam .RData file, 3: output counts .RData file
+library(riboSeqR)
+library(tools)
+
+args = commandArgs(trailingOnly=TRUE)
+
+chlamyFastaState <- (args[1])
+load(chlamyFastaState) # fastaCDA from prepare-fastaCDA.R
+
+ribofilesState <-  (args[2])
+load(ribofilesState) # riboDat from prepare-ribodat.R
+
+#Count reads across ORFs, keeping track of what frame they fall into
+fCs <- frameCounting(riboDat, fastaCDS, length = c(20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38))
+fS <- readingFrame(rC = fCs, lengths = c(20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38))
+
+save(fCs, fS, file=args[3])

--- a/metariboseq/workflows/analysis/prepare-fastaCDS.R
+++ b/metariboseq/workflows/analysis/prepare-fastaCDS.R
@@ -1,0 +1,9 @@
+# Takes arguments - 1: fasta file, 2: output RData file
+library(riboSeqR)
+
+args = commandArgs(trailingOnly=TRUE)
+
+chlamyFasta <- (args[1])
+#Load in asssembly and annotate ORFs
+fastaCDS <- findCDS(fastaFile = chlamyFasta,startCodon = c("ATG"),stopCodon = c("TAG", "TAA", "TGA"))
+save(fastaCDS, file=args[2])

--- a/metariboseq/workflows/analysis/prepare-ribodat.R
+++ b/metariboseq/workflows/analysis/prepare-ribodat.R
@@ -1,0 +1,9 @@
+# Takes arguments - 1: Ribo bam file, 2: output RData file
+library(riboSeqR)
+
+args = commandArgs(trailingOnly=TRUE)
+
+ribofiles <-  (args[1])
+#Load in asssembly and annotate ORFs
+riboDat <- readRibodata(ribofiles, replicates = 1)
+save(riboDat, file=args[2])

--- a/metariboseq/workflows/bin/run-nextflow-common.sh
+++ b/metariboseq/workflows/bin/run-nextflow-common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-root="/labs/asbhatt/cosn/bhattlab_workflows/metariboseq"
+root="/labs/asbhatt/cosn/github.com/bhattlab/bhattlab_workflows/metariboseq"
 
 container="${root}/singularity/$1"
 nextflow=$2
@@ -21,6 +21,13 @@ case "$1" in
 "scg-all")
     configs="$configs,${root}/nextflow-configs/slurm.config"
     paramsfile="${params}/params-all.yml"
+    ;;
+"mpgriesh-all-local")
+    paramsfile="${params}/params-mpgriesh.yml"
+    ;;
+"mpgriesh-all")
+    configs="$configs,${root}/nextflow-configs/slurm.config"
+    paramsfile="${params}/params-mpgriesh.yml"
     ;;
 *)
     echo "unrecognised mode: $1"


### PR DESCRIPTION
This PR updates the workflows to avoid duplicate processing of metagenomic assemblies which can be shared across samples. It also breaks up the analysis workflow into separable stages to make it easier to work with samples that have low coverage and hence which can't be fully processed - without these changes the overall analysis scripts will fail with hard to diagnose errors.